### PR TITLE
Added range checking in Python functions. 

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -15,11 +15,10 @@
   the internal MT19937 objects. The CPython implementation has a global interpreter lock, and (looking at the Python
   bytecode disassembly) a C function call corresponds to a single Python bytecode instruction. Hence, there are no race
   conditions to worry about, and the provided functions are thread-safe.
-  * The Python API functions are given names similar to those below. Nevertheless, you can view *their* documentation
-    by entering `import mt19937` and then `help(mt19937)` at the Python REPL.
-  * Since Python uses arbitrary-precision integers, it is possible for a Python integer to not be exactly representable
-    as a C integer. Weird things may happen if the Python functions are called with out-of-range numbers; I make no
-    attempt to mitigate this.
+  * The Python API functions are given names similar to those below. Nevertheless, you can see a summary by entering
+    `import mt19937` and then `help(mt19937)` at the Python REPL.
+  * It is possible for a Python integer to not be exactly representable as a C integer. To mitigate this, appropriate
+    range checks are automatically done on all Python integers.
 
 ---
 
@@ -131,7 +130,7 @@ previous function should be used.
 ---
 
 ```C
-void mt19937_drop32(int long long unsigned count, struct mt19937_32_t *mt);
+void mt19937_drop32(int long long count, struct mt19937_32_t *mt);
 ```
 Advance the state of the pseudorandom number generator. Equivalent to running `mt19937_rand32(mt)` `count` times and
 discarding the results.
@@ -139,7 +138,7 @@ discarding the results.
 * `mt` MT19937 object to use. Optional. If not provided, the internal 32-bit MT19937 object is used.
 
 ```C
-void mt19937_drop64(int long long unsigned count, struct mt19937_64_t *mt);
+void mt19937_drop64(int long long count, struct mt19937_64_t *mt);
 ```
 Advance the state of the pseudorandom number generator. Equivalent to running `mt19937_rand64(mt)` `count` times and
 discarding the results.

--- a/include/mt19937.h
+++ b/include/mt19937.h
@@ -33,8 +33,8 @@ double mt19937_real32(struct mt19937_32_t *mt);
 double long mt19937_real64(struct mt19937_64_t *mt);
 void mt19937_shuffle32(void *items, uint32_t num_of_items, size_t size_of_item, struct mt19937_32_t *mt);
 void mt19937_shuffle64(void *items, uint64_t num_of_items, size_t size_of_item, struct mt19937_64_t *mt);
-void mt19937_drop32(int long long unsigned count, struct mt19937_32_t *mt);
-void mt19937_drop64(int long long unsigned count, struct mt19937_64_t *mt);
+void mt19937_drop32(int long long count, struct mt19937_32_t *mt);
+void mt19937_drop64(int long long count, struct mt19937_64_t *mt);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/mt19937_defs.c
+++ b/lib/mt19937_defs.c
@@ -134,7 +134,7 @@ void MT19937_SHUFFLE(void *items, MT19937_WORD num_of_items, size_t size_of_item
 }
 
 
-void MT19937_DROP(int long long unsigned count, MT19937_OBJECT_TYPE *mt)
+void MT19937_DROP(int long long count, MT19937_OBJECT_TYPE *mt)
 {
     while(count-- > 0)
     {

--- a/lib/pymt19937.c
+++ b/lib/pymt19937.c
@@ -6,37 +6,49 @@
 
 static PyObject *seed32(PyObject *self, PyObject *args)
 {
-    int long unsigned seed = 0;
-    if(!PyArg_ParseTuple(args, "|k", &seed))
+    int long unsigned seed;
+    if(!PyArg_ParseTuple(args, "k", &seed))
     {
         return NULL;
     }
-    mt19937_seed32(seed, NULL);
+    seed = PyLong_AsUnsignedLong(PyTuple_GET_ITEM(args, 0));
+    if(PyErr_Occurred() || seed > 4294967295UL)
+    {
+        PyErr_SetString(PyExc_ValueError, "argument 1 must be an integer in the range [0, 4294967295]");
+        return NULL;
+    }
+    mt19937_seed32((uint32_t)seed, NULL);
     Py_RETURN_NONE;
 }
 
 
 static PyObject *seed64(PyObject *self, PyObject *args)
 {
-    int long long unsigned seed = 0;
-    if(!PyArg_ParseTuple(args, "|K", &seed))
+    int long long unsigned seed;
+    if(!PyArg_ParseTuple(args, "K", &seed))
     {
         return NULL;
     }
-    mt19937_seed64(seed, NULL);
+    seed = PyLong_AsUnsignedLongLong(PyTuple_GET_ITEM(args, 0));
+    if(PyErr_Occurred() || seed > 18446744073709551615ULL)
+    {
+        PyErr_SetString(PyExc_ValueError, "argument 1 must be an integer in the range [0, 18446744073709551615]");
+        return NULL;
+    }
+    mt19937_seed64((uint64_t)seed, NULL);
     Py_RETURN_NONE;
 }
 
 
 static PyObject *rand32(PyObject *self, PyObject *args)
 {
-    return PyLong_FromUnsignedLong(mt19937_rand32(NULL));
+    return PyLong_FromUnsignedLong((int long unsigned)mt19937_rand32(NULL));
 }
 
 
 static PyObject *rand64(PyObject *self, PyObject *args)
 {
-    return PyLong_FromUnsignedLongLong(mt19937_rand64(NULL));
+    return PyLong_FromUnsignedLongLong((int long long unsigned)mt19937_rand64(NULL));
 }
 
 
@@ -47,12 +59,13 @@ static PyObject *uint32(PyObject *self, PyObject *args)
     {
         return NULL;
     }
-    if(modulus == 0)
+    modulus = PyLong_AsUnsignedLong(PyTuple_GET_ITEM(args, 0));
+    if(PyErr_Occurred() || modulus == 0 || modulus > 4294967295UL)
     {
-        PyErr_SetString(PyExc_RuntimeError, "argument 1 must be non-zero");
+        PyErr_SetString(PyExc_ValueError, "argument 1 must be an integer in the range [1, 4294967295]");
         return NULL;
     }
-    return PyLong_FromUnsignedLong(mt19937_uint32(modulus, NULL));
+    return PyLong_FromUnsignedLong((int long unsigned)mt19937_uint32((uint32_t)modulus, NULL));
 }
 
 
@@ -63,44 +76,67 @@ static PyObject *uint64(PyObject *self, PyObject *args)
     {
         return NULL;
     }
-    if(modulus == 0)
+    modulus = PyLong_AsUnsignedLongLong(PyTuple_GET_ITEM(args, 0));
+    if(PyErr_Occurred() || modulus == 0 || modulus > 18446744073709551615ULL)
     {
-        PyErr_SetString(PyExc_RuntimeError, "argument 1 must be non-zero");
+        PyErr_SetString(PyExc_ValueError, "argument 1 must be an integer in the range [1, 18446744073709551615]");
         return NULL;
     }
-    return PyLong_FromUnsignedLongLong(mt19937_uint64(modulus, NULL));
+    return PyLong_FromUnsignedLongLong((int long long unsigned)mt19937_uint64((uint64_t)modulus, NULL));
 }
 
 
 static PyObject *span32(PyObject *self, PyObject *args)
 {
     int long left, right;
+    PyObject *err = NULL;
     if(!PyArg_ParseTuple(args, "ll", &left, &right))
     {
-        return NULL;
+        err = PyErr_Occurred();
+        if(!PyErr_GivenExceptionMatches(err, PyExc_OverflowError))
+        {
+            return NULL;
+        }
     }
-    if(right <= left)
+    if(err != NULL
+    || left < -2147483647L - 1 || left > 2147483647L
+    || right < -2147483647L - 1 || right > 2147483647L
+    || left >= right)
     {
-        PyErr_SetString(PyExc_RuntimeError, "argument 1 must be less than argument 2");
+        PyErr_SetString(
+            PyExc_ValueError,
+            "arguments 1 and 2 must be integers in the range [-2147483648, 2147483647]; "
+            "argument 1 must be less than argument 2");
         return NULL;
     }
-    return PyLong_FromLong(mt19937_span32(left, right, NULL));
+    return PyLong_FromLong((int long)mt19937_span32((int32_t)left, (int32_t)right, NULL));
 }
 
 
 static PyObject *span64(PyObject *self, PyObject *args)
 {
     int long long left, right;
+    PyObject *err = NULL;
     if(!PyArg_ParseTuple(args, "LL", &left, &right))
     {
-        return NULL;
+        err = PyErr_Occurred();
+        if(!PyErr_GivenExceptionMatches(err, PyExc_OverflowError))
+        {
+            return NULL;
+        }
     }
-    if(right <= left)
+    if(err != NULL
+    || left < -9223372036854775807LL - 1 || left > 9223372036854775807LL
+    || right < -9223372036854775807LL - 1 || right > 9223372036854775807LL
+    || left >= right)
     {
-        PyErr_SetString(PyExc_RuntimeError, "argument 1 must be less than argument 2");
+        PyErr_SetString(
+            PyExc_ValueError,
+            "arguments 1 and 2 must be integers in the range [-9223372036854775808, 9223372036854775807]; "
+            "argument 1 must be less than argument 2");
         return NULL;
     }
-    return PyLong_FromLongLong(mt19937_span64(left, right, NULL));
+    return PyLong_FromLongLong((int long long)mt19937_span64((int64_t)left, (int64_t)right, NULL));
 }
 
 
@@ -112,14 +148,14 @@ static PyObject *real32(PyObject *self, PyObject *args)
 
 static PyObject *real64(PyObject *self, PyObject *args)
 {
-    return PyFloat_FromDouble(mt19937_real64(NULL));
+    return PyFloat_FromDouble((double)mt19937_real64(NULL));
 }
 
 
 static PyObject *drop32(PyObject *self, PyObject *args)
 {
-    int long long unsigned count;
-    if(!PyArg_ParseTuple(args, "K", &count))
+    int long long count;
+    if(!PyArg_ParseTuple(args, "L", &count))
     {
         return NULL;
     }
@@ -130,8 +166,8 @@ static PyObject *drop32(PyObject *self, PyObject *args)
 
 static PyObject *drop64(PyObject *self, PyObject *args)
 {
-    int long long unsigned count;
-    if(!PyArg_ParseTuple(args, "K", &count))
+    int long long count;
+    if(!PyArg_ParseTuple(args, "L", &count))
     {
         return NULL;
     }
@@ -144,12 +180,12 @@ static PyObject *drop64(PyObject *self, PyObject *args)
 PyDoc_STRVAR(
     seed32_doc,
     "Python API for `mt19937_seed32`.\n\n"
-    ":param seed: 32-bit number. Optional. If this is not specified, it is the same as if it were 0."
+    ":param seed: 32-bit number. If this is 0, it will be seeded with the sum of the Unix time and the process ID."
 );
 PyDoc_STRVAR(
     seed64_doc,
     "Python API for `mt19937_seed64`.\n\n"
-    ":param seed: 64-bit number. Optional. If this is not specified, it is the same as if it were 0."
+    ":param seed: 64-bit number. If this is 0, it will be seeded with the sum of the Unix time and the process ID."
 );
 PyDoc_STRVAR(
     rand32_doc,
@@ -164,27 +200,27 @@ PyDoc_STRVAR(
 PyDoc_STRVAR(
     uint32_doc,
     "Python API for `mt19937_uint32`.\n\n"
-    ":param modulus: 32-bit number. Raises `RuntimeError` if this is 0.\n\n"
+    ":param modulus: 32-bit number. Must not be 0.\n\n"
     ":return: Uniform pseudorandom 32-bit number from 0 (inclusive) to `modulus` (exclusive)."
 );
 PyDoc_STRVAR(
     uint64_doc,
     "Python API for `mt19937_uint64`.\n\n"
-    ":param modulus: 64-bit number. Raises `RuntimeError` if this is 0.\n\n"
+    ":param modulus: 64-bit number. Must not be 0.\n\n"
     ":return: Uniform pseudorandom 64-bit number from 0 (inclusive) to `modulus` (exclusive)."
 );
 PyDoc_STRVAR(
     span32_doc,
     "Python API for `mt19937_span32`.\n\n"
     ":param left: 32-bit number.\n"
-    ":param right: 32-bit number. Raises `RuntimeError` if this is less than or equal to `left`.\n\n"
+    ":param right: 32-bit number. Must be greater than `left`.\n\n"
     ":return: Uniform pseudorandom 32-bit number from `left` (inclusive) to `right` (exclusive)."
 );
 PyDoc_STRVAR(
     span64_doc,
     "Python API for `mt19937_span64`.\n\n"
     ":param left: 64-bit number.\n"
-    ":param right: 64-bit number. Raises `RuntimeError` if this is less than or equal to `left`.\n\n"
+    ":param right: 64-bit number. Must be greater than `left`.\n\n"
     ":return: Uniform pseudorandom 64-bit number from `left` (inclusive) to `right` (exclusive)."
 );
 PyDoc_STRVAR(
@@ -227,7 +263,8 @@ static PyModuleDef pymt19937_module =
 {
     PyModuleDef_HEAD_INIT,
     "mt19937",
-    "Python API for a C implementation of MT19937",
+    "Python API for a C implementation of MT19937 "
+    "(see https://github.com/tfpf/mersenne-twister/blob/main/doc for the full documentation)",
     -1,
     pymt19937_methods,
 };


### PR DESCRIPTION
Fixes https://github.com/tfpf/mersenne-twister/issues/1.

C functions have no argument checking, which is par for course for C. Python functions should provide a safety net, however.
* Unsigned integers: used `PyLong_As*` functions after `PyArg_ParseTuple` to check whether values are in range of `int long unsigned` and `int long long unsigned`.
  * Because the latter function does not check for overflow for unsigned integers.
* Signed integers: `PyArg_ParseTuple` already checks whether values are in range of `int long` and `int long long`.
* For both, added manual checks for the values, because, for instance, `int long` may not have the same range as `int32_t`.
  * If the conversion of a Python integer to a C `int long` succeeded, I still don't know if the value will fit in a C `int32_t`.
  * A manual check for the range fixes that problem, but to do that, there is another complication.
  * `-9223372036854775808LL` may be an invalid `int long long` literal (it may be so large that it becomes unsigned).
  * C processes that literal as a unary minus applied to a positive literal, but `9223372036854775808LL` may be out of range of `int long long`!
  * Hence, it's necessary to write `-9223372036854775807LL - 1`. I have done the same in the 32-bit case for consistency.
* Added casts where necessary. For example:
  * `PyLong_FromLong` converts `int long` to a Python integer, but `mt19937_span32` returns `int32_t`, which may not have the same range/encoding as `int long`; and
  * `mt19937_span32` expects `int32_t` arguments, but `PyArg_ParseTuple` yields `int long` variables.
* Changed the argument type of `drop32` and `drop64` functions to `int long long` to get the range checking benefit of `PyArg_ParseTuple`.
* Updated documentation for the same.
* Updated Python documentation with a link to the documentation file on GitHub.
  * Made Python documentation in line with main documentation.