### PR TITLE
Added functions to seed with unspecified value. Allowed 0 seed.

### DIFF
--- a/benchmarks/benchmarks.cc
+++ b/benchmarks/benchmarks.cc
@@ -22,10 +22,10 @@
  *****************************************************************************/
 int main(void)
 {
-    BENCHMARK(mt19937_seed32(0), 0x10000)
-    BENCHMARK(mt19937_seed64(0), 0x10000)
-    BENCHMARK(mt19937_rand32(), 0x270000)
-    BENCHMARK(mt19937_rand64(), 0x270000)
-    BENCHMARK(mt19937_real32(), 0x270000)
-    BENCHMARK(mt19937_real64(), 0x270000)
+    BENCHMARK(mt19937_init32(), 0x10000)
+    BENCHMARK(mt19937_init64(), 0x10000)
+    BENCHMARK(mt19937_rand32(), 0x27000)
+    BENCHMARK(mt19937_rand64(), 0x27000)
+    BENCHMARK(mt19937_real32(), 0x27000)
+    BENCHMARK(mt19937_real64(), 0x27000)
 }

--- a/doc/README.md
+++ b/doc/README.md
@@ -39,6 +39,20 @@ Seed 64-bit MT19937.
 ---
 
 ```C
+void mt19937_init32(struct mt19937_32_t *mt);
+```
+Seed 32-bit MT19937 with an unspecified value generated at run-time.
+* `mt` MT19937 object to seed. Optional. If not provided, the internal 32-bit MT19937 object is seeded.
+
+```C
+void mt19937_init64(struct mt19937_64_t *mt);
+```
+Seed 64-bit MT19937 with an unspecified value generated at run-time.
+* `mt` MT19937 object to seed. Optional. If not provided, the internal 64-bit MT19937 object is seeded.
+
+---
+
+```C
 uint32_t mt19937_rand32(struct mt19937_32_t *mt);
 ```
 Generate a pseudorandom number.

--- a/include/mt19937.h
+++ b/include/mt19937.h
@@ -23,6 +23,8 @@ extern "C"
 #endif
 void mt19937_seed32(uint32_t seed, struct mt19937_32_t *mt);
 void mt19937_seed64(uint64_t seed, struct mt19937_64_t *mt);
+void mt19937_init32(struct mt19937_32_t *mt);
+void mt19937_init64(struct mt19937_64_t *mt);
 uint32_t mt19937_rand32(struct mt19937_32_t *mt);
 uint64_t mt19937_rand64(struct mt19937_64_t *mt);
 uint32_t mt19937_uint32(uint32_t modulus, struct mt19937_32_t *mt);
@@ -46,6 +48,8 @@ void mt19937_drop64(int long long count, struct mt19937_64_t *mt);
 
 #define mt19937_seed32(seed, ...) mt19937_seed32(seed, GET_OR_NULL(__VA_ARGS__ __VA_OPT__(,) NULL))
 #define mt19937_seed64(seed, ...) mt19937_seed64(seed, GET_OR_NULL(__VA_ARGS__ __VA_OPT__(,) NULL))
+#define mt19937_init32(...) mt19937_init32(GET_OR_NULL(__VA_ARGS__ __VA_OPT__(,) NULL))
+#define mt19937_init64(...) mt19937_init64(GET_OR_NULL(__VA_ARGS__ __VA_OPT__(,) NULL))
 #define mt19937_rand32(...) mt19937_rand32(GET_OR_NULL(__VA_ARGS__ __VA_OPT__(,) NULL))
 #define mt19937_rand64(...) mt19937_rand64(GET_OR_NULL(__VA_ARGS__ __VA_OPT__(,) NULL))
 #define mt19937_uint32(modulus, ...) mt19937_uint32(modulus, GET_OR_NULL(__VA_ARGS__ __VA_OPT__(,) NULL))

--- a/lib/mt19937.c
+++ b/lib/mt19937.c
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <unistd.h>
 
 #include "mt19937.h"
 
@@ -12,6 +11,8 @@
 // argument of those functions.
 #undef mt19937_seed32
 #undef mt19937_seed64
+#undef mt19937_init32
+#undef mt19937_init64
 #undef mt19937_rand32
 #undef mt19937_rand64
 #undef mt19937_uint32
@@ -36,6 +37,7 @@
 #define MT19937_OBJECT mt19937_32
 #define MT19937_REAL_TYPE double
 #define MT19937_SEED mt19937_seed32
+#define MT19937_INIT mt19937_init32
 #define MT19937_RAND mt19937_rand32
 #define MT19937_UINT mt19937_uint32
 #define MT19937_SPAN mt19937_span32
@@ -152,6 +154,7 @@ static MT19937_OBJECT_TYPE MT19937_OBJECT =
 #undef MT19937_OBJECT
 #undef MT19937_REAL_TYPE
 #undef MT19937_SEED
+#undef MT19937_INIT
 #undef MT19937_RAND
 #undef MT19937_UINT
 #undef MT19937_SPAN
@@ -183,6 +186,7 @@ static MT19937_OBJECT_TYPE MT19937_OBJECT =
 #define MT19937_OBJECT mt19937_64
 #define MT19937_REAL_TYPE double long
 #define MT19937_SEED mt19937_seed64
+#define MT19937_INIT mt19937_init64
 #define MT19937_RAND mt19937_rand64
 #define MT19937_UINT mt19937_uint64
 #define MT19937_SPAN mt19937_span64
@@ -299,6 +303,7 @@ static MT19937_OBJECT_TYPE MT19937_OBJECT =
 #undef MT19937_OBJECT
 #undef MT19937_REAL_TYPE
 #undef MT19937_SEED
+#undef MT19937_INIT
 #undef MT19937_RAND
 #undef MT19937_UINT
 #undef MT19937_SPAN

--- a/lib/mt19937_defs.c
+++ b/lib/mt19937_defs.c
@@ -1,10 +1,6 @@
 void MT19937_SEED(MT19937_WORD seed, MT19937_OBJECT_TYPE *mt)
 {
     mt = mt == NULL ? &MT19937_OBJECT : mt;
-    if(seed == 0)
-    {
-        seed = time(NULL) + getpid();
-    }
     mt->state[0] = seed;
     for(int i = 1; i < MT19937_STATE_LENGTH; ++i)
     {
@@ -13,6 +9,12 @@ void MT19937_SEED(MT19937_WORD seed, MT19937_OBJECT_TYPE *mt)
         mt->state[i] = MT19937_MULTIPLIER * (mt->state[i - 1] ^ shifted) + i;
     }
     mt->index = MT19937_STATE_LENGTH;
+}
+
+
+void MT19937_INIT(MT19937_OBJECT_TYPE *mt)
+{
+    MT19937_SEED(time(NULL), mt);
 }
 
 

--- a/lib/pymt19937.c
+++ b/lib/pymt19937.c
@@ -40,6 +40,20 @@ static PyObject *seed64(PyObject *self, PyObject *args)
 }
 
 
+static PyObject *init32(PyObject *self, PyObject *args)
+{
+    mt19937_init32(NULL);
+    Py_RETURN_NONE;
+}
+
+
+static PyObject *init64(PyObject *self, PyObject *args)
+{
+    mt19937_init64(NULL);
+    Py_RETURN_NONE;
+}
+
+
 static PyObject *rand32(PyObject *self, PyObject *args)
 {
     return PyLong_FromUnsignedLong((int long unsigned)mt19937_rand32(NULL));
@@ -180,12 +194,20 @@ static PyObject *drop64(PyObject *self, PyObject *args)
 PyDoc_STRVAR(
     seed32_doc,
     "Seed 32-bit MT19937.\n\n"
-    ":param seed: 32-bit number. If this is 0, it will be seeded with the sum of the Unix time and the process ID."
+    ":param seed: 32-bit number."
 );
 PyDoc_STRVAR(
     seed64_doc,
     "Seed 64-bit MT19937.\n\n"
-    ":param seed: 64-bit number. If this is 0, it will be seeded with the sum of the Unix time and the process ID."
+    ":param seed: 64-bit number."
+);
+PyDoc_STRVAR(
+    init32_doc,
+    "Seed 32-bit MT19937 with an unspecified value generated at run-time."
+);
+PyDoc_STRVAR(
+    init64_doc,
+    "Seed 64-bit MT19937 with an unspecified value generated at run-time."
 );
 PyDoc_STRVAR(
     rand32_doc,
@@ -249,6 +271,8 @@ static PyMethodDef pymt19937_methods[] =
 {
     {"seed32", seed32, METH_VARARGS, seed32_doc},
     {"seed64", seed64, METH_VARARGS, seed64_doc},
+    {"init32", init32, METH_NOARGS, init32_doc},
+    {"init64", init64, METH_NOARGS, init64_doc},
     {"rand32", rand32, METH_NOARGS, rand32_doc},
     {"rand64", rand64, METH_NOARGS, rand64_doc},
     {"uint32", uint32, METH_VARARGS, uint32_doc},


### PR DESCRIPTION
 Fixes https://github.com/tfpf/mersenne-twister/issues/3.

* Wrote C functions: `mt19937_init32` and `mt19937_init64`.
  * Using 0 as the seed when calling `mt19937_seed32` and `mt19937_seed64` now actually seeds with 0 rather than with `time(NULL) + getpid()`.
  * Removed `unistd.h` header because `getpid` is not used now. This makes this code completely standard C.
* Wrote Python functions: `init32` and `init64`.
* Changed the benchmark program to use these new functions for seeding.
* Updated all documentation for these changes.